### PR TITLE
Adding libonig.so to prevent php error at nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ php:
   - '7.1'
   - '7.2'
   - nightly
+addons:
+  apt:
+    packages:
+      - libonig-dev
 script:
   - ./run_cold_start.php --rps=100 --users=1000 --time=20 1>/dev/null
   - ./run_cold_start.php --rps=100 --users=1000 --time=20 --random 1>/dev/null


### PR DESCRIPTION
This is a fix of failed Travis builds for PHP nightly.

Build log details:
```
0.02s$ phpenv global nightly 2>/dev/null
nightly is not pre-installed; installing
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/14.04/x86_64/php-nightly.tar.bz2
9.60s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
0.01s0.02s$ phpenv global nightly
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
0.05s$ composer self-update
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
$ php --version
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
$ composer --version
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
0.05s$ ./run_cold_start.php --rps=100 --users=1000 --time=20 1>/dev/null
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
The command "./run_cold_start.php --rps=100 --users=1000 --time=20 1>/dev/null" exited with 127.
0.05s$ ./run_cold_start.php --rps=100 --users=1000 --time=20 --random 1>/dev/null
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
The command "./run_cold_start.php --rps=100 --users=1000 --time=20 --random 1>/dev/null" exited with 127.
0.05s$ ./run_modulo_resharding.php --keys=1000 --servers=4,5 1>/dev/null
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
The command "./run_modulo_resharding.php --keys=1000 --servers=4,5 1>/dev/null" exited with 127.
0.05s$ ./run_modulo_resharding.php --keys=1000 --servers="1-10" 1>/dev/null
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
The command "./run_modulo_resharding.php --keys=1000 --servers="1-10" 1>/dev/null" exited with 127.
Done. Your build exited with 1.
```
